### PR TITLE
Sample for resetting clutter to dedicated pose in skrl

### DIFF
--- a/source/extensions/omni.isaac.lab_tasks/omni/isaac/lab_tasks/skrl_custom/trainers/torch/base.py
+++ b/source/extensions/omni.isaac.lab_tasks/omni/isaac/lab_tasks/skrl_custom/trainers/torch/base.py
@@ -211,7 +211,13 @@ class Trainer:
             else:
                 if terminated.any() or truncated.any():
                     with torch.no_grad():
-                        states, infos = self.env.reset()
+                        states, infos = self.env.reset() # states is just observation, not full sim state
+                        curr_state = self.env.scene.get_state(False) # curr_state is full sim state
+                        num_clutter_objects = 6
+                        for i in range(num_clutter_objects):
+                            pose = curr_state["rigid_object"][f"clutter_object{i+1}"]['root_pose']
+                            pose[:, :3] = torch.tensor([0.5, 0, i/3]).to(pose.device) # just demo with height set to i/3 - spawn with z-stacked pos
+                        self.env.reset_to(curr_state, None)
                 else:
                     states = next_states
 


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html
-->

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
